### PR TITLE
更新文本框不超过7行显示；调整窗口自动滚屏到最后

### DIFF
--- a/js/chat.js
+++ b/js/chat.js
@@ -61,8 +61,18 @@ function autoresize() {
     var height = div.height();
     var rows = Math.ceil(height / 20);
     div.remove();
-    textarea.attr('rows', rows);
+    if(rows>=7){
+        textarea.attr('wrap', 'off');
+        textarea.attr('style', 'overflow:scroll;');
+        textarea.attr('rows', '7');
+    }
+    else
+        textarea.attr('rows', rows);
     $("#article-wrapper").height(parseInt($(window).height()) - parseInt($("#fixed-block").height()) - parseInt($(".layout-header").height()) - 80);
+}
+
+function scrollEnd() {
+    $("#article-wrapper").scrollTop(parseInt($(window).height()));
 }
 
 $(document).ready(function () {
@@ -77,10 +87,12 @@ $(document).ready(function () {
 
     $(window).resize(function () {
         autoresize();
+        scrollEnd();
     });
 
     $('#kw-target').on('input', function () {
         autoresize();
+        scrollEnd();
     });
 
     $("#ai-btn").click(function () {


### PR DESCRIPTION
文本框如果粘贴很长的内容会覆盖掉输出显示，不太美观，参考官方chatgpt网页，只显示几行代码。
增加调整窗口自动滚屏到最后的代码