### PR TITLE
[Bug Fix] Character deletion error 修复回答的字符缺失

### DIFF
--- a/js/chat.js
+++ b/js/chat.js
@@ -265,7 +265,7 @@ $(document).ready(function () {
                         if (newalltext.split("\n").length == 1) {
                             newalltext = newalltext.replace(/\\n/g, '\n');
                         }
-                        if (str_.length < (newalltext.length - 3)) {
+                        if (str_.length < (newalltext.length)) {
                             str_ += newalltext[i++];
                             strforcode = str_;
                             if ((str_.split("```").length % 2) == 0) {


### PR DESCRIPTION
[Bug Fix] Character deletion error 修复回答的字符缺失

复现步骤：在正常提问（使用了中文与英文提问），收到回答后，最后显示的内容在最后有缺失。观察chatlog和浏览器端网络请求，发现内容均完整。

重现频率：每次

修改：问题疑似是 newalltext.length 处变更所致，在删去 -3 后该 bug 消失。

第一次提交pr，错误及不善之处还请大佬谅解指教，谢谢。